### PR TITLE
Add #21: 모든 법정동 코드 받아오기 -> 각 법정동에 있는 아파트 정보 받아와서 저장하기

### DIFF
--- a/src/main/java/com/project/homeFinder/batch/job/step/reader/OpenDataApiApartmentBasicInfoReader.java
+++ b/src/main/java/com/project/homeFinder/batch/job/step/reader/OpenDataApiApartmentBasicInfoReader.java
@@ -4,7 +4,10 @@ import com.project.homeFinder.dto.response.raw.xml.ApartmentListResponseRaw;
 import com.project.homeFinder.service.api.OpenDataApi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.item.*;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.NonTransientResourceException;
+import org.springframework.batch.item.ParseException;
+import org.springframework.batch.item.UnexpectedInputException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,7 +26,11 @@ public class OpenDataApiApartmentBasicInfoReader implements ItemReader<Apartment
      */
     @Override
     public ApartmentListResponseRaw read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
-        if (IS_END) {
+        if (IS_END) { // Read가 끝나는 시점
+            IS_END = false; // Read가 끝나는 시점에서, 다시 IS_END를 초기화 시켜줘야, 다음 법정동 코드로 Read 할때 바로 종료가 안됨 
+                            // -> 현재 Read가 끝나면, apartmentBasicInfoXmlResponseRawItemReader에서 OpenDataApiApartmentBasicInfoReader 객체를 새로 만들지 않고, 처음 호출 됐을때 생성된 객체를 다시 사용
+                            //  ->파라미터 값들이 계속 유지됨 -> 그러므로, IS_END랑 page 값들을 초기화 시켜줘야 함
+            page = 1;
             return null;
         }
 
@@ -34,8 +41,8 @@ public class OpenDataApiApartmentBasicInfoReader implements ItemReader<Apartment
             data = openDataApi.openDataFindAllAptBjdCode(page, size, BJD_CODE);
         }
 
-        log.info("[OpenDataApiApartmentBasicInfoReader] currentPage={}", page);
-        if (data.fetchItems().size() == 0 || page > 5) {
+        log.info("[OpenDataApiApartmentBasicInfoReader] BJD_CODE={}, currentPage={}", BJD_CODE, page);
+        if (data.fetchItems().size() == 0) {
             return null;
         }
         if(data.fetchItems().size() < size){

--- a/src/main/java/com/project/homeFinder/batch/tasklet/ReadBjdCodeTasklet.java
+++ b/src/main/java/com/project/homeFinder/batch/tasklet/ReadBjdCodeTasklet.java
@@ -1,0 +1,105 @@
+package com.project.homeFinder.batch.tasklet;
+
+import com.project.homeFinder.repository.BjdCodeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 1. sidoCode로 BjdCode 테이블에 접근해서 모든 튜플들 가져와서 List<String> bjdCodes에 저장
+ * 2. ReadBjdCodeTasklet이 호출될떄 마다, bjdCodes를 하나씩 가져와서 ChunkContext에 저장
+ * 3. ItemReader에서 ChunckContext에 저장된 법정동 코드를 가져와서 아파트 정보 가져오기
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReadBjdCodeTasklet implements Tasklet {
+
+    private String SEOUL_CODE = "11";
+    private String BJD_CODE_LIST = "bjdCodeList";
+    private String BJD_CODE = "bjdCode";
+    private String ITEM_COUNT = "itemCount";
+
+    private List<String> bjdCodes = new ArrayList<>();
+    private int itemCount = 0;
+
+    private final BjdCodeRepository bjdCodeRepository;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        ExecutionContext jobExecutionContext = getExecutionContext(chunkContext);
+
+        initExecutionContext(jobExecutionContext);
+        initItemCount(jobExecutionContext);
+
+        /**
+         * 더이상 읽을 데이터가 없을때
+         */
+        if (itemCount == 0) {
+            contribution.setExitStatus(ExitStatus.COMPLETED);
+
+            return RepeatStatus.FINISHED;
+        }
+
+        itemCount--;
+
+        /**
+         * ExecutionContext 는 Key-Value 로 값을 저장함
+         */
+        log.info("BJD_CODE = {}", bjdCodes.get(itemCount));
+        jobExecutionContext.putString(BJD_CODE, bjdCodes.get(itemCount));
+        jobExecutionContext.putInt(ITEM_COUNT, itemCount);
+
+        /**
+         * 데이터가 있으면 다음 Step 실행. 없으면 종료.
+         * 데이터가 있으면 -> CONTINUABLE
+         */
+        contribution.setExitStatus(new ExitStatus("CONTINUABLE"));
+
+        return RepeatStatus.FINISHED;
+    }
+
+    private ExecutionContext getExecutionContext(ChunkContext chunkContext) {
+        /**
+         * ExecutionContext 를 가져오기 위해 먼저 현재 Step 의 StepExecution  가져오기
+         */
+        StepExecution stepExecution = chunkContext.getStepContext().getStepExecution();
+
+        /**
+         * 현재 Job 에서의 ExecutionContext 를 가져오기
+         * -> ExecutionContext 를 통해서 Step 끼리 데이터를 주고 받음
+         */
+        return stepExecution.getJobExecution().getExecutionContext();
+    }
+
+    private void initExecutionContext(ExecutionContext executionContext){
+        if (executionContext.containsKey(BJD_CODE_LIST)) {
+            bjdCodes = (List<String>) executionContext.get(BJD_CODE_LIST);
+        } else {
+            /**
+             * Step 을 처음 실행하면 ExecutionContext 에 값들이 없기 때문에 값들을 저장 시켜주기
+             */
+            bjdCodes = bjdCodeRepository.findAllBySidoCode(SEOUL_CODE);
+            executionContext.put(BJD_CODE_LIST, bjdCodes);
+            executionContext.putInt(ITEM_COUNT, bjdCodes.size());
+        }
+    }
+
+    private void initItemCount(ExecutionContext executionContext) {
+        if (executionContext.containsKey(ITEM_COUNT)) {
+            itemCount = executionContext.getInt(ITEM_COUNT);
+        } else {
+            itemCount = bjdCodes.size();
+        }
+    }
+}

--- a/src/main/java/com/project/homeFinder/dto/response/KakaoSearchByAddressResponse.java
+++ b/src/main/java/com/project/homeFinder/dto/response/KakaoSearchByAddressResponse.java
@@ -25,9 +25,23 @@ public class KakaoSearchByAddressResponse {
 
     public static KakaoSearchByAddressResponse fromComplexAddress(KakaoSearchByAddressResponseRaw.ComplexAddress complexAddress) {
         return new KakaoSearchByAddressResponse(
-                complexAddress.getRoad_address().getAddress_name(),
+                addressExists(complexAddress) ? complexAddress.getRoad_address().getAddress_name() : "",
                 complexAddress.getX(),
                 complexAddress.getY()
         );
+    }
+
+    private static boolean addressExists(KakaoSearchByAddressResponseRaw.ComplexAddress complexAddress) {
+        if(complexAddress == null){
+            return false;
+        }
+        if(complexAddress.getRoad_address() == null){
+            return false;
+        }
+        if(complexAddress.getRoad_address().getAddress_name() == null){
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
* [readAllBjdCodeStep] -> [ReadBjdCodeTasklet] -> [apartmentInfoInsertStep] -> [apartmentBasicInfoXmlResponseRawItemReader] -> [apartmentBasicInfoXmlResponseRawItemProcessor] -> [apartmentBasicInfoXmlResponseRawItemWriter] -> [readAllBjdCodeStep] -> ...

    * 모든 법정동 코드 가져옴 -> 순서대로 ChunkContext에 주입 -> apartmentInfoInsertStep에서 ChunkContext에서 법정동 코드 가져와서 아파트 정보들 받아오고 저장 -> readAllBjdCodeStep에서 그 다음 법정동 코드를 ChunkContext에 저장 -> ...

* [ReadBjdCodeTasklet]: BjdCodeRepository에서 모든 법정동 코드 가져와서 리스트에 저장
* [ReadBjdCodeTasklet]: 법정동 코드가 저장되어 있는 리스트에서 각 값을 순서대로 가져와서 ChunkContext에 저장
* [OpenDataApiApartmentBasicInfoReader] : ChunkContext에서 법정동 코드를 가져와서 공공데이터 아파트 정보 API 호출
* [apartmentInfoInsertStep] 가 처음 호출될때 apartmentBasicInfoXmlResponseRawItemReader 에서 OpenDataApiApartmentBasicInfoReader 객체 생성 후, apartmentInfoInsertStep이 끝나고 readAllBjdCodeStep이 다시 호출 된 이후 다시 한번 apartmentInfoInsertStep이 호출될때, OpenDataApiApartmentBasicInfoReader를 새로 생성하지 않기 때문에 OpenDataApiApartmentBasicInfoReader의 종료 조건(IS_END)를 초기화 해줘야함